### PR TITLE
Use single intermediate CA certs instead of cert chains with root CA cert

### DIFF
--- a/tls/tls-full/config_template.yaml
+++ b/tls/tls-full/config_template.yaml
@@ -125,35 +125,35 @@ global:
                 keyFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.key
                 requireClientAuth: true
                 clientCaFiles:
-                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca-chain.pem
+                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca.pem
             client:
                 serverName: internode.cluster-x.contoso.com
                 rootCaFiles:
-                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca-chain.pem
+                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca.pem
         frontend:
             server:
                 requireClientAuth: true
                 certFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.pem
                 keyFile: /etc/temporal/config/certs/cluster/internode/cluster-internode.key
                 clientCaFiles:
-                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca-chain.pem
+                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca.pem
             client:
                 serverName: internode.cluster-x.contoso.com
                 rootCaFiles:
-                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca-chain.pem
+                    - /etc/temporal/config/certs/cluster/ca/server-intermediate-ca.pem
             hostOverrides:
                 accounting.cluster-x.contoso.com:
                     certFile: /etc/temporal/config/certs/cluster/accounting/cluster-accounting-chain.pem
                     keyFile: /etc/temporal/config/certs/cluster/accounting/cluster-accounting.key
                     requireClientAuth: true
                     clientCaFiles:
-                        - /etc/temporal/config/certs/client/ca/client-intermediate-ca-accounting-chain.pem
+                        - /etc/temporal/config/certs/client/ca/client-intermediate-ca-accounting.pem
                 development.cluster-x.contoso.com:
                     certFile: /etc/temporal/config/certs/cluster/development/cluster-development-chain.pem
                     keyFile: /etc/temporal/config/certs/cluster/development/cluster-development.key
                     requireClientAuth: true
                     clientCaFiles:
-                        - /etc/temporal/config/certs/client/ca/client-intermediate-ca-development-chain.pem
+                        - /etc/temporal/config/certs/client/ca/client-intermediate-ca-development.pem
     {{- if .Env.STATSD_ENDPOINT }}
     metrics:
         statsd:

--- a/tls/tls-full/docker-compose.yml
+++ b/tls/tls-full/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - ${TEMPORAL_LOCAL_CERT_DIR}:${TEMPORAL_TLS_CERTS_DIR}
     environment:
       - "TEMPORAL_CLI_ADDRESS=temporal:7233"
-      - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca-chain.pem"
+      - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca.pem"
       - "TEMPORAL_CLI_TLS_CERT=${TEMPORAL_TLS_CERTS_DIR}/cluster/internode/cluster-internode.pem"
       - "TEMPORAL_CLI_TLS_KEY=${TEMPORAL_TLS_CERTS_DIR}/cluster/internode/cluster-internode.key"
       - "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION=true"
@@ -42,7 +42,7 @@ services:
       - ${TEMPORAL_LOCAL_CERT_DIR}:${TEMPORAL_TLS_CERTS_DIR}
     environment:
       - "TEMPORAL_CLI_ADDRESS=temporal:7233"
-      - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca-chain.pem"
+      - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca.pem"
       - "TEMPORAL_CLI_TLS_CERT=${TEMPORAL_TLS_CERTS_DIR}/client/accounting/client-accounting-namespace-chain.pem"
       - "TEMPORAL_CLI_TLS_KEY=${TEMPORAL_TLS_CERTS_DIR}/client/accounting/client-accounting-namespace.key"
       - "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION=true"
@@ -57,7 +57,7 @@ services:
       - ${TEMPORAL_LOCAL_CERT_DIR}:${TEMPORAL_TLS_CERTS_DIR}
     environment:
       - "TEMPORAL_CLI_ADDRESS=temporal:7233"
-      - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca-chain.pem"
+      - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca.pem"
       - "TEMPORAL_CLI_TLS_CERT=${TEMPORAL_TLS_CERTS_DIR}/client/development/client-development-namespace-chain.pem"
       - "TEMPORAL_CLI_TLS_KEY=${TEMPORAL_TLS_CERTS_DIR}/client/development/client-development-namespace.key"
       - "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION=true"

--- a/tls/tls-full/generate-certs.sh
+++ b/tls/tls-full/generate-certs.sh
@@ -27,14 +27,17 @@ generate_cert() {
     openssl genrsa -out $2/$1.key 4096
     openssl req -new -key $2/$1.key -out $TEMP_DIR/$1.csr -config $1.conf
     openssl x509 -req -in $TEMP_DIR/$1.csr -CA $3.pem -CAkey $3.key -CAcreateserial -out $2/$1.pem -days 365 -extfile $1.conf -extensions $4
-    cat $2/$1.pem $3.pem > $2/$1-chain.pem
+    if [[ $5 != 'no_chain' ]]
+    then
+      cat $2/$1.pem $3.pem > $2/$1-chain.pem
+    fi
 }
 
 echo Generate a private key and a certificate for server root CA
 generate_root_ca_cert server-root-ca $CLUSTER_DIR/ca
 
 echo Generate a private key and a certificate for server intermediate CA
-generate_cert server-intermediate-ca $CLUSTER_DIR/ca $CLUSTER_DIR/ca/server-root-ca v3_ca
+generate_cert server-intermediate-ca $CLUSTER_DIR/ca $CLUSTER_DIR/ca/server-root-ca v3_ca no_chain
 
 echo Generate a private key and a certificate for internode communication 
 generate_cert cluster-internode $CLUSTER_DIR/internode $CLUSTER_DIR/ca/server-intermediate-ca req_ext
@@ -50,10 +53,10 @@ echo Generate a private key and a certificate for client root CA
 generate_root_ca_cert client-root-ca $CLIENT_DIR/ca
 
 echo Generate a private key and a certificate for client intermediate CA for accounting namespace
-generate_cert client-intermediate-ca-accounting $CLIENT_DIR/ca $CLIENT_DIR/ca/client-root-ca v3_ca
+generate_cert client-intermediate-ca-accounting $CLIENT_DIR/ca $CLIENT_DIR/ca/client-root-ca v3_ca no_chain
 
 echo Generate a private key and a certificate for client intermediate CA for development namespace
-generate_cert client-intermediate-ca-development $CLIENT_DIR/ca $CLIENT_DIR/ca/client-root-ca v3_ca
+generate_cert client-intermediate-ca-development $CLIENT_DIR/ca $CLIENT_DIR/ca/client-root-ca v3_ca no_chain
 
 echo Generate a private key and a certificate for accounting namespace client 
 generate_cert client-accounting-namespace $CLIENT_DIR/accounting $CLIENT_DIR/ca/client-intermediate-ca-accounting req_ext


### PR DESCRIPTION
Root CA certs should not be included with intermediate CA certs because that leads to undesired successful validation or leaf certs issues by other intermediate CA certs originating from the same root CA.