### PR TITLE
Fixes README instructions

### DIFF
--- a/tls/tls-full/README.md
+++ b/tls/tls-full/README.md
@@ -3,10 +3,10 @@ This sample demonstrates how to configure Transport Layer Security (TLS) to secu
 It also shows how different clients can be given different server certificates when connecting to the same cluster using different server names.
 
 ### Steps to run this sample
-1. Generate test certificates with `generate-test-certs.sh`. This will create server and client certificates in the `certs` subdirectory.
+1. Generate test certificates with `generate-certs.sh`. This will create server and client certificates in a `certs` subdirectory.
 
 ```bash
-bash generate-test-certs.sh
+bash generate-certs.sh
 ```
 
 2. Start Temporal with `start-temporal.sh`. This will bring up a Temporal cluster (via `docker-compose`) with the `certs` subdirectory mounted as a volume and Temporal configured to use the test certificates in it to secure network communications.


### PR DESCRIPTION
The file title seemed to be duplicated from the `tls-simple` directory.