### PR TITLE
Add client-only alpine linux and mac scripts to generate certificates

### DIFF
--- a/tls/client-only/README.md
+++ b/tls/client-only/README.md
@@ -38,6 +38,5 @@ hash --> will automatically follow the guidelines in RFC3280
 ### Notes
 - The generated certificates are hard-coded as valid for 365 days
 - This requires two separate scripts to run to make it possible to both create a variable number of end-entity certificates at any point in time. 
-- It's also worth noting here that we are generating configuration files as opposed to setting the entered values from arguments because the domain name is unable to be set as a param when generating an x509 cert, at present. 
 
 [1]: https://www.openssl.org/docs/man1.1.1/man5/x509v3_config.html

--- a/tls/client-only/README.md
+++ b/tls/client-only/README.md
@@ -1,0 +1,43 @@
+### Overview
+
+These scripts generate only the client-side certificates, along with their keys and configuration files. Alpine Linux and Mac are both supported in their given folders. 
+
+### User Instructions 
+
+2. To generate the root certificate run the `ca.sh` script.
+3. To generate an end-entity certificate, run the `end-entity` script.
+
+### Additional Documentation 
+
+x509v3_config:
+
+critical --> ["If critical is present then the extension will be critical."][1]
+
+[v3_ca]
+
+authorityKeyIdentifier = keyid:always,issuer
+keyid:always,issuer --> an attempt is made to copy the subject key identifier from the parent certificate. If the value "always" is present then an error is returned if the option fails.
+[source][1]
+
+basicConstraints = critical,CA:TRUE,pathlen:0
+CA:TRUE --> This is a certificate authority 
+pathlen:0 --> "indicates the maximum number of CAs that can appear below this one in a chain. So if you have a CA with a pathlen of zero it can only be used to sign end user certificates and not further CAs."
+[source][1]
+[source](https://stackoverflow.com/questions/6616470/certificates-basic-constraints-path-length/6617814#6617814)
+
+keyUsage = critical,digitalSignature,cRLSign,keyCertSign
+digitalSignature --> Certificate may be used to apply a digital signature
+cRLSign --> Subject public key is to verify signatures on revocation information, such as a CRL
+keyCertSign --> Subject public key is used to verify signatures on certificates
+[source](https://superuser.com/questions/738612/openssl-ca-keyusage-extension)
+
+subjectKeyIdentifier = hash
+hash --> will automatically follow the guidelines in RFC3280
+[source][1]
+
+### Notes
+- The generated certificates are hard-coded as valid for 365 days
+- This requires two separate scripts to run to make it possible to both create a variable number of end-entity certificates at any point in time. 
+- It's also worth noting here that we are generating configuration files as opposed to setting the entered values from arguments because the domain name is unable to be set as a param when generating an x509 cert, at present. 
+
+[1]: https://www.openssl.org/docs/man1.1.1/man5/x509v3_config.html

--- a/tls/client-only/README.md
+++ b/tls/client-only/README.md
@@ -38,5 +38,6 @@ hash --> will automatically follow the guidelines in RFC3280
 ### Notes
 - The generated certificates are hard-coded as valid for 365 days
 - This requires two separate scripts to run to make it possible to both create a variable number of end-entity certificates at any point in time. 
+- These certificates should be used only to inform that a connection can be made, and is not to be used in production. 
 
 [1]: https://www.openssl.org/docs/man1.1.1/man5/x509v3_config.html

--- a/tls/client-only/README.md
+++ b/tls/client-only/README.md
@@ -1,6 +1,6 @@
 ### Overview
 
-These scripts generate only the client-side certificates, along with their keys and configuration files. Alpine Linux and Mac are both supported in their given folders. 
+These scripts generate only the client-side certificates, along with their keys and configuration files. Alpine Linux and Mac are both supported in their given folders. If you're having trouble with these scripts in your local environment, take a look at our [Docker Image for generation client-side certificates](https://hub.docker.com/r/temporalio/client-certificate-generation). 
 
 ### User Instructions 
 

--- a/tls/client-only/alpine/ca.sh
+++ b/tls/client-only/alpine/ca.sh
@@ -9,7 +9,7 @@ read COMPANY_NAME
 CN="${COMPANY_NAME,,}"
 
 ## Return a random stream of data, fold makes a new line every 4 characters, head will take the first line. 
-RANDLETTER=$(cat /dev/urandom | busybox tr -dc 'a-zA-Z0-9' | busybox fold -w 4 | busybox head -n 1)
+RANDLETTER=$(cat /dev/urandom | busybox tr -dc 'a-z0-9' | busybox fold -w 4 | busybox head -n 1)
 
 DNS_ROOT="client.root.${CN}.${RANDLETTER}"
 

--- a/tls/client-only/alpine/ca.sh
+++ b/tls/client-only/alpine/ca.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+echo "Creating the CSR (certificate signing request)"
+
+## This will also be used as the DNS for the end-entity
+echo "What is your company name?:"
+read COMPANY_NAME
+
+CN="${COMPANY_NAME,,}"
+
+## Return a random stream of data, fold makes a new line every 4 characters, head will take the first line. 
+RANDLETTER=$(cat /dev/urandom | busybox tr -dc 'a-zA-Z0-9' | busybox fold -w 4 | busybox head -n 1)
+
+DNS_ROOT="client.root.${CN}.${RANDLETTER}"
+
+GENERATED_ROOT_CONF_FILE="ca.conf"
+cat << EOF > ${GENERATED_ROOT_CONF_FILE}
+[req]
+default_bits = 4096
+default_md = sha256
+req_extensions = req_ext
+x509_extensions = v3_ca
+distinguished_name = dn
+prompt = no
+
+[v3_ca]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,digitalSignature,cRLSign,keyCertSign
+
+[req_ext]
+subjectAltName = @alt_names
+
+[dn]
+O = $COMPANY_NAME
+
+[alt_names]
+DNS.1 = $DNS_ROOT
+
+EOF
+
+openssl genrsa -out ca.key 4096
+openssl req -new -x509 -days 365 -key ca.key -out ca.pem -config ca.conf
+
+echo "Printing root CA certificate"
+openssl x509 -in ca.pem -noout -text
+
+echo "---> Keep ca.key and ca.pem secure, but available for generating end entities in the future"

--- a/tls/client-only/alpine/end-entity.sh
+++ b/tls/client-only/alpine/end-entity.sh
@@ -12,7 +12,7 @@ IFS="." read -a strarr <<< "${DNS}"
 CN="${strarr[3]}"
 
 # Return a random stream of data, fold makes a new line every 4 characters, head will take the first line. 
-RANDLETTER=$(cat /dev/urandom | busybox tr -dc 'a-zA-Z0-9' | busybox fold -w 4 | busybox head -n 1)
+RANDLETTER=$(cat /dev/urandom | busybox tr -dc 'a-z0-9' | busybox fold -w 4 | busybox head -n 1)
 
 # Enter this as the DNS. 
 DNS_END_ENTITY="client.endentity.${CN}.${RANDLETTER}"

--- a/tls/client-only/alpine/end-entity.sh
+++ b/tls/client-only/alpine/end-entity.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+echo "Enter a unique name for the prefix of the .pem and .key files":
+read UNIQUE_NAME
+echo "Generating private key and CSR"
+
+# Grep other conf file to grab company name.
+DNS=$(grep DNS.1 ca.conf)
+
+# Find the company name e.g. from `DNS.1=client.root.<company name>.<rand values>` 
+IFS="." read -a strarr <<< "${DNS}"
+CN="${strarr[3]}"
+
+# Return a random stream of data, fold makes a new line every 4 characters, head will take the first line. 
+RANDLETTER=$(cat /dev/urandom | busybox tr -dc 'a-zA-Z0-9' | busybox fold -w 4 | busybox head -n 1)
+
+# Enter this as the DNS. 
+DNS_END_ENTITY="client.endentity.${CN}.${RANDLETTER}"
+
+GENERATED_END_ENTITY_CONF_FILE="${UNIQUE_NAME}.conf"
+cat << EOF > ${GENERATED_END_ENTITY_CONF_FILE}
+[req]
+default_bits = 4096
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+prompt = no
+
+[req_ext]
+subjectAltName = @alt_names
+
+[dn]
+O = $CN
+
+[alt_names]
+DNS.1 = $DNS_END_ENTITY
+EOF
+
+# Generate client's private key and certificate signing request (CSR)
+openssl req -newkey rsa:4096 -nodes -keyout "${UNIQUE_NAME}.key" -out "${UNIQUE_NAME}-req.pem" -config "${UNIQUE_NAME}.conf"
+
+echo "Signing certificate"
+
+# Use CA's private key to sign client's CSR and get back the signed certificate
+openssl x509 -days 365 -req -in "${UNIQUE_NAME}-req.pem" -CA "ca.pem" -CAkey "ca.key" -CAcreateserial -out "${UNIQUE_NAME}.pem" -extfile "${UNIQUE_NAME}.conf"
+
+# Delete the certificate signing request after the certificate has been signed. 
+rm "${UNIQUE_NAME}-req.pem"
+
+echo "Printing signed end-entity certificate"
+openssl x509 -in "${UNIQUE_NAME}.pem" -noout -text
+
+echo "---> Keep these files secure, and use ${UNIQUE_NAME}.pem and ${UNIQUE_NAME}.key in the SDK"

--- a/tls/client-only/mac/ca.sh
+++ b/tls/client-only/mac/ca.sh
@@ -10,7 +10,7 @@ read COMPANY_NAME
 CN=$(echo $COMPANY_NAME | awk '{print tolower($0)}')
 
 ## Return a random stream of data, fold makes a new line every 4 characters, head will take the first line. 
-RANDLETTER=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
+RANDLETTER=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
 DNS_ROOT="client.root.${CN}.${RANDLETTER}"
 
 touch ca.conf

--- a/tls/client-only/mac/ca.sh
+++ b/tls/client-only/mac/ca.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+echo "Creating the CSR (certificate signing request)"
+
+## This will also be used as the DNS for the end-entity.
+echo "What is your company name?:"
+read COMPANY_NAME
+
+# Lower case company name for DNS.
+CN=$(echo $COMPANY_NAME | awk '{print tolower($0)}')
+
+#RANDLETTER=$(C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 4 ; echo '')
+RANDLETTER=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
+
+## Return a random stream of data, fold makes a new line every 4 characters, head will take the first line. 
+#RANDLETTER=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
+
+
+DNS_ROOT="client.root.${CN}.${RANDLETTER}"
+
+touch ca.conf
+chmod 0755 ca.conf 
+
+GENERATED_ROOT_CONF_FILE="ca.conf"
+cat << EOF > ${GENERATED_ROOT_CONF_FILE}
+[req]
+default_bits = 4096
+default_md = sha256
+req_extensions = req_ext
+x509_extensions = v3_ca
+distinguished_name = dn
+prompt = no
+
+[v3_ca]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical,CA:TRUE,pathlen:0
+keyUsage = critical,digitalSignature,cRLSign,keyCertSign
+
+[req_ext]
+subjectAltName = @alt_names
+
+[dn]
+O = $COMPANY_NAME
+
+[alt_names]
+DNS.1 = $DNS_ROOT
+
+EOF
+
+openssl genrsa -out ca.key 4096
+chmod 0755 ca.key 
+
+openssl req -new -x509 -days 365 -key ca.key -out ca.pem -config ca.conf
+chmod 0755 ca.pem 
+
+echo "Printing root CA certificate"
+openssl x509 -in ca.pem -noout -text
+
+echo "---> Keep ca.key and ca.pem secure, but available for generating end entities in the future"

--- a/tls/client-only/mac/ca.sh
+++ b/tls/client-only/mac/ca.sh
@@ -2,20 +2,15 @@
 
 echo "Creating the CSR (certificate signing request)"
 
-## This will also be used as the DNS for the end-entity.
+## This will also be used as part of the DNS for the CA and end-entity in addition to the organization setting.
 echo "What is your company name?:"
 read COMPANY_NAME
 
 # Lower case company name for DNS.
 CN=$(echo $COMPANY_NAME | awk '{print tolower($0)}')
 
-#RANDLETTER=$(C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 4 ; echo '')
-RANDLETTER=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
-
 ## Return a random stream of data, fold makes a new line every 4 characters, head will take the first line. 
-#RANDLETTER=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
-
-
+RANDLETTER=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
 DNS_ROOT="client.root.${CN}.${RANDLETTER}"
 
 touch ca.conf

--- a/tls/client-only/mac/end-entity.sh
+++ b/tls/client-only/mac/end-entity.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+echo "Enter a unique name for the prefix of the .pem and .key files":
+read UNIQUE_NAME
+echo "Generating private key and CSR"
+
+# Grep other conf file to grab company name.
+DNS=$(grep DNS.1 ca.conf)
+
+# Find the company name e.g. from `DNS.1=client.root.<company name>.<rand values>` 
+IFS="." read -a strarr <<< "${DNS}"
+CN="${strarr[3]}"
+
+# Return a random stream of data, fold makes a new line every 4 characters, head will take the first line. 
+RANDLETTER=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
+
+# Enter this as the DNS. 
+DNS_END_ENTITY="client.endentity.${CN}.${RANDLETTER}"
+
+GENERATED_END_ENTITY_CONF_FILE="${UNIQUE_NAME}.conf"
+cat << EOF > ${GENERATED_END_ENTITY_CONF_FILE}
+[req]
+default_bits = 4096
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+prompt = no
+
+[req_ext]
+subjectAltName = @alt_names
+
+[dn]
+O = $CN
+
+[alt_names]
+DNS.1 = $DNS_END_ENTITY
+EOF
+
+# Generate client's private key and certificate signing request (CSR)
+openssl req -newkey rsa:4096 -nodes -keyout "${UNIQUE_NAME}.key" -out "${UNIQUE_NAME}-req.pem" -config "${UNIQUE_NAME}.conf"
+
+echo "Signing certificate"
+
+# Use CA's private key to sign client's CSR and get back the signed certificate
+openssl x509 -days 365 -req -in "${UNIQUE_NAME}-req.pem" -CA "ca.pem" -CAkey "ca.key" -CAcreateserial -out "${UNIQUE_NAME}.pem" -extfile "${UNIQUE_NAME}.conf"
+
+# Delete the certificate signing request after the certificate has been signed. 
+rm "${UNIQUE_NAME}-req.pem"
+
+echo "Printing signed end-entity certificate"
+openssl x509 -in "${UNIQUE_NAME}.pem" -noout -text
+
+echo "---> Keep these files secure, and use ${UNIQUE_NAME}.pem and ${UNIQUE_NAME}.key in the SDK"

--- a/tls/client-only/mac/end-entity.sh
+++ b/tls/client-only/mac/end-entity.sh
@@ -12,7 +12,7 @@ IFS="." read -a strarr <<< "${DNS}"
 CN="${strarr[3]}"
 
 # Return a random stream of data, fold makes a new line every 4 characters, head will take the first line. 
-RANDLETTER=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
+RANDLETTER=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
 
 # Enter this as the DNS. 
 DNS_END_ENTITY="client.endentity.${CN}.${RANDLETTER}"


### PR DESCRIPTION
## What was changed:
I added client-only scripts that support both mac and alpine linux, along with documentation.

## Why?
Users who have need of client-only certificates may use these.