### PR TITLE
Fix stale documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 These samples show how to customize Temporal server for specific production scenarios.
 
 Learn more about Temporal at:
-* Documentation: https://docs.temporal.io/docs/overview/
-* Main repository: https://github.com/temporalio/temporal,
+* Documentation: https://docs.temporal.io
+* Main repository: https://github.com/temporalio/temporal
 * Go SDK: https://github.com/temporalio/sdk-go
 * Java SDK: https://github.com/temporalio/sdk-java
 

--- a/extensibility/authorizer/README.md
+++ b/extensibility/authorizer/README.md
@@ -4,7 +4,7 @@ This sample shows how to inject a low-level authorizer component that can contro
 The sample implementation of the authorizer interface `authorization.Authorizer` allows all requests to the "temporal-system" namespace and denies `UpdateNamespace` calls for all other namespaces.
 
 ### Steps to run this sample
-1. Start up the dependencies by running the `make start-dependencies` command from within the main Temporal repository as described in the [contribution guide](https://github.com/temporalio/temporal/blob/master/CONTRIBUTING.md#runing-server-locally).
+1. Start up the dependencies by running the `make start-dependencies` command from within the main Temporal repository as described in the [contribution guide](https://github.com/temporalio/temporal/blob/master/CONTRIBUTING.md#run-temporal-server-locally).
 
 2. Create the database schema by running `make install-schema`.
 


### PR DESCRIPTION
Update a couple of broken documentation links and remove an inconsistent comma in a bullet list.
