### PR TITLE
Allow setting docker image versions in TLS full-sample

### DIFF
--- a/tls/tls-full/docker-compose.yml
+++ b/tls/tls-full/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "9042:9042"
   temporal:
-    image: temporalio/auto-setup
+    image: temporalio/auto-setup:${SERVER_TAG:-latest}
     ports:
       - "7233:7233"
     volumes:
@@ -26,7 +26,7 @@ services:
     depends_on:
       - cassandra
   temporal-web:
-    image: temporalio/web
+    image: temporalio/web:${WEB_TAG:-latest}
     ports:
       - "8088:8088"
     volumes:
@@ -41,7 +41,7 @@ services:
     depends_on:
       - temporal
   temporal-cli-admin:
-    image: temporalio/admin-tools
+    image: temporalio/admin-tools:${SERVER_TAG:-latest}
     stdin_open: true
     tty: true
     volumes:
@@ -56,7 +56,7 @@ services:
     depends_on:
       - temporal
   temporal-cli-accounting:
-    image: temporalio/admin-tools
+    image: temporalio/admin-tools:${SERVER_TAG:-latest}
     stdin_open: true
     tty: true
     volumes:
@@ -71,7 +71,7 @@ services:
     depends_on:
       - temporal
   temporal-cli-development:
-    image: temporalio/admin-tools
+    image: temporalio/admin-tools:${SERVER_TAG:-latest}
     stdin_open: true
     tty: true
     volumes:

--- a/tls/tls-simple/docker-compose.yml
+++ b/tls/tls-simple/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "9042:9042"
   temporal:
-    image: temporalio/auto-setup:${SERVER_TAG:-1.2.1}
+    image: temporalio/auto-setup:${SERVER_TAG:-latest}
     ports:
       - "7233:7233"
     volumes:
@@ -31,7 +31,7 @@ services:
     depends_on:
       - cassandra
   temporal-web:
-    image: temporalio/web:${WEB_TAG:-1.12.0}
+    image: temporalio/web:${WEB_TAG:-latest}
     ports:
       - "8088:8088"
     volumes:
@@ -46,7 +46,7 @@ services:
     depends_on:
       - temporal
   temporal-admin-tools:
-    image: temporalio/admin-tools:${SERVER_TAG:-1.2.1}
+    image: temporalio/admin-tools:${SERVER_TAG:-latest}
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

* Allows to set Temporal Server and Web docker image tags through env variables
* Set `latest` as the default version 

## Why?
<!-- Tell your future self why have you made these changes -->

* `tls-simple` sample was outdated. It doesn't work with the latest docker images. Want to incentivize us to make sure our samples work with the latest versions

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

* `./start-server.sh`
* verify the Web UI loads namespaces

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
