### PR TITLE
VLN-501: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/extensibility.yaml
+++ b/.github/workflows/extensibility.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'extensibility/**'
 
+permissions:
+  contents: read
+
 jobs:
   extensibility-test:
     strategy:

--- a/.github/workflows/promql-to-dd-go.yaml
+++ b/.github/workflows/promql-to-dd-go.yaml
@@ -16,6 +16,9 @@ on:
       - '!cloud/observability/promql-to-dd-go/examples/**'
       - '!cloud/observability/promql-to-dd-go/helm-charts/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: ./.github/workflows/promql-to-dd-go_test.yaml

--- a/.github/workflows/promql-to-dd-go_test.yaml
+++ b/.github/workflows/promql-to-dd-go_test.yaml
@@ -3,6 +3,9 @@ name: Test
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
## Summary

- `.github/workflows/extensibility.yaml`: Added a workflow-level `permissions` block granting only `contents: read`, which is sufficient for checkout and build steps.
- `.github/workflows/promql-to-dd-go_test.yaml`: Declared workflow-level `permissions` with `contents: read` to cover checkout and test execution.
- `.github/workflows/promql-to-dd-go.yaml`: Applied a workflow-level `permissions` block restricted to `contents: read` for the reusable workflow invocations.