### PR TITLE
fix: context deadline exceeded error in create-namespace.sh init script

### DIFF
--- a/compose/scripts/create-namespace.sh
+++ b/compose/scripts/create-namespace.sh
@@ -1,18 +1,24 @@
 #!/bin/sh
 set -eu
-
 NAMESPACE=${DEFAULT_NAMESPACE:-default}
 TEMPORAL_ADDRESS=${TEMPORAL_ADDRESS:-temporal:7233}
 
+TEMPORAL_HOST=$(echo $TEMPORAL_ADDRESS | cut -d: -f1)
+TEMPORAL_PORT=$(echo $TEMPORAL_ADDRESS | cut -d: -f2)
+
 echo "Waiting for Temporal server port to be available..."
-nc -z -w 10 $(echo $TEMPORAL_ADDRESS | cut -d: -f1) $(echo $TEMPORAL_ADDRESS | cut -d: -f2)
+nc -z -w 10 $TEMPORAL_HOST $TEMPORAL_PORT
 echo 'Temporal server port is available'
+
+# Resolve hostname to IPv4 to work around some very weird issue
+TEMPORAL_IP=$(getent ahosts $TEMPORAL_HOST | grep STREAM | head -1 | awk '{print $1}')
+RESOLVED_ADDRESS="${TEMPORAL_IP}:${TEMPORAL_PORT}"
+echo "Resolved $TEMPORAL_ADDRESS to $RESOLVED_ADDRESS"
 
 echo 'Waiting for Temporal server to be healthy...'
 max_attempts=3
 attempt=0
-
-until temporal operator cluster health --address $TEMPORAL_ADDRESS; do
+until temporal operator cluster health --address $RESOLVED_ADDRESS; do
   attempt=$((attempt + 1))
   if [ $attempt -ge $max_attempts ]; then
     echo "Server did not become healthy after $max_attempts attempts"
@@ -23,5 +29,5 @@ until temporal operator cluster health --address $TEMPORAL_ADDRESS; do
 done
 
 echo "Server is healthy, creating namespace '$NAMESPACE'..."
-temporal operator namespace describe -n $NAMESPACE --address $TEMPORAL_ADDRESS || temporal operator namespace create -n $NAMESPACE --address $TEMPORAL_ADDRESS
+temporal operator namespace describe -n $NAMESPACE --address $RESOLVED_ADDRESS || temporal operator namespace create -n $NAMESPACE --address $RESOLVED_ADDRESS
 echo "Namespace '$NAMESPACE' created"


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
The create-namespace.sh was adjusted to talk to the temporal server via it's IP instead of the docker compose container / service name.

## Why?
Because for some reason outside my understanding, it doesn't work when you use the compose service name. Technically this is probably a bug in the temporal cli itself and should be fixed there. If you can point me in the right direction on where I have to go/check to fix this, I would probably be willing to take a look at that too.

## Checklist
<!--- add/delete as needed --->

1. Closes #136

2. How was this tested:
First clone the repo, then run `docker compose -f docker-compose-postgres.yml up -d`. I validated that the temporal server is reachable from an application using the Java SDK.
