### PR TITLE
fix: replace SERVICES with TEMPORAL_SERVICES and add service validation

### DIFF
--- a/.github/workflows/compose.yaml
+++ b/.github/workflows/compose.yaml
@@ -270,6 +270,39 @@ jobs:
           check_no_port temporal-worker 7237
           check_no_port temporal-worker 7236
 
+      - name: Verify ringpop membership ports are reachable on temporal-network
+        run: |
+          port_listening() {
+            container=$1
+            port=$2
+            hex_port=$(printf '%04X' "$port")
+            docker exec "$container" cat /proc/net/tcp /proc/net/tcp6 2>/dev/null \
+              | awk '{print $2}' | grep -qi ":${hex_port}$"
+          }
+
+          # Check membership ports are listening inside each container
+          for entry in "temporal-history:6934" "temporal-matching:6935"; do
+            container=${entry%:*}
+            port=${entry#*:}
+            if ! port_listening "$container" "$port"; then
+              echo "FAIL: $container is not listening on membership port $port"
+              docker exec "$container" cat /proc/net/tcp /proc/net/tcp6 2>/dev/null || true
+              exit 1
+            fi
+            echo "OK: $container is listening on membership port $port"
+          done
+
+          # Verify membership ports are reachable from within temporal-network
+          for entry in "temporal-history:6934" "temporal-matching:6935"; do
+            target=${entry%:*}
+            port=${entry#*:}
+            if ! docker exec temporal-admin-tools nc -zw3 "$target" "$port"; then
+              echo "FAIL: $target:$port is not reachable on temporal-network"
+              exit 1
+            fi
+            echo "OK: $target:$port is reachable on temporal-network"
+          done
+
       - name: Print all logs on failure
         if: failure()
         working-directory: compose

--- a/.github/workflows/compose.yaml
+++ b/.github/workflows/compose.yaml
@@ -211,6 +211,63 @@ jobs:
         run: |
           docker compose -f docker-compose-multirole.yaml ps temporal-history temporal-frontend temporal-matching temporal-worker
 
+      - name: Verify each container runs only its expected service
+        run: |
+          port_listening() {
+            container=$1
+            port=$2
+            docker exec "$container" ss -tln 2>/dev/null | grep -qE ":${port}[[:space:]]"
+          }
+
+          check_expected_port() {
+            container=$1
+            port=$2
+            if ! port_listening "$container" "$port"; then
+              echo "FAIL: $container is not listening on expected port $port"
+              docker exec "$container" ss -tln 2>/dev/null || true
+              exit 1
+            fi
+            echo "OK: $container is listening on port $port"
+          }
+
+          check_no_port() {
+            container=$1
+            port=$2
+            if port_listening "$container" "$port"; then
+              echo "FAIL: $container is unexpectedly listening on port $port"
+              exit 1
+            fi
+            echo "OK: $container is not listening on port $port"
+          }
+
+          # history: port 7234 only
+          check_expected_port temporal-history 7234
+          check_no_port temporal-history 7235
+          check_no_port temporal-history 7237
+          check_no_port temporal-history 7236
+
+          # matching: port 7235 only
+          check_expected_port temporal-matching 7235
+          check_no_port temporal-matching 7234
+          check_no_port temporal-matching 7237
+          check_no_port temporal-matching 7236
+
+          # frontend: port 7237 (FRONTEND_GRPC_PORT=7237)
+          check_expected_port temporal-frontend 7237
+          check_no_port temporal-frontend 7234
+          check_no_port temporal-frontend 7235
+
+          # frontend2: port 7236 (FRONTEND_GRPC_PORT=7236)
+          check_expected_port temporal-frontend2 7236
+          check_no_port temporal-frontend2 7234
+          check_no_port temporal-frontend2 7235
+
+          # worker: should not bind any of the other service ports
+          check_no_port temporal-worker 7234
+          check_no_port temporal-worker 7235
+          check_no_port temporal-worker 7237
+          check_no_port temporal-worker 7236
+
       - name: Print all logs on failure
         if: failure()
         working-directory: compose

--- a/.github/workflows/compose.yaml
+++ b/.github/workflows/compose.yaml
@@ -216,7 +216,9 @@ jobs:
           port_listening() {
             container=$1
             port=$2
-            docker exec "$container" ss -tln 2>/dev/null | grep -qE ":${port}[[:space:]]"
+            hex_port=$(printf '%04X' "$port")
+            docker exec "$container" cat /proc/net/tcp /proc/net/tcp6 2>/dev/null \
+              | awk '{print $2}' | grep -qi ":${hex_port}$"
           }
 
           check_expected_port() {
@@ -224,7 +226,7 @@ jobs:
             port=$2
             if ! port_listening "$container" "$port"; then
               echo "FAIL: $container is not listening on expected port $port"
-              docker exec "$container" ss -tln 2>/dev/null || true
+              docker exec "$container" cat /proc/net/tcp /proc/net/tcp6 2>/dev/null || true
               exit 1
             fi
             echo "OK: $container is listening on port $port"

--- a/compose/docker-compose-multirole.yaml
+++ b/compose/docker-compose-multirole.yaml
@@ -108,7 +108,7 @@ services:
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
       - TEMPORAL_HISTORY_NAMESPACEDEFAULT_ARCHIVAL_FILESTORE=enabled
       - TEMPORAL_VISIBILITY_NAMESPACEDEFAULT_ARCHIVAL_FILESTORE=enabled
-      - SERVICES=history
+      - TEMPORAL_SERVICES=history
       - PROMETHEUS_ENDPOINT=0.0.0.0:8000
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
@@ -141,7 +141,7 @@ services:
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
       - TEMPORAL_HISTORY_NAMESPACEDEFAULT_ARCHIVAL_FILESTORE=enabled
       - TEMPORAL_VISIBILITY_NAMESPACEDEFAULT_ARCHIVAL_FILESTORE=enabled
-      - SERVICES=matching
+      - TEMPORAL_SERVICES=matching
       - PROMETHEUS_ENDPOINT=0.0.0.0:8001
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
@@ -174,7 +174,7 @@ services:
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
       - TEMPORAL_HISTORY_NAMESPACEDEFAULT_ARCHIVAL_FILESTORE=enabled
       - TEMPORAL_VISIBILITY_NAMESPACEDEFAULT_ARCHIVAL_FILESTORE=enabled
-      - SERVICES=frontend
+      - TEMPORAL_SERVICES=frontend
       - FRONTEND_GRPC_PORT=7237
       - PROMETHEUS_ENDPOINT=0.0.0.0:8002
       - ENABLE_ES=true
@@ -208,7 +208,7 @@ services:
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
       - TEMPORAL_HISTORY_NAMESPACEDEFAULT_ARCHIVAL_FILESTORE=enabled
       - TEMPORAL_VISIBILITY_NAMESPACEDEFAULT_ARCHIVAL_FILESTORE=enabled
-      - SERVICES=frontend
+      - TEMPORAL_SERVICES=frontend
       # set different frontend grpc port
       - FRONTEND_GRPC_PORT=7236
       # set different membership port than temporal-frontend
@@ -245,7 +245,7 @@ services:
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
       - TEMPORAL_HISTORY_NAMESPACEDEFAULT_ARCHIVAL_FILESTORE=enabled
       - TEMPORAL_VISIBILITY_NAMESPACEDEFAULT_ARCHIVAL_FILESTORE=enabled
-      - SERVICES=worker
+      - TEMPORAL_SERVICES=worker
       - PROMETHEUS_ENDPOINT=0.0.0.0:8003
       # set to nginx
       - PUBLIC_FRONTEND_ADDRESS=temporal-nginx:7233

--- a/tls/tls-full/docker-compose.yml
+++ b/tls/tls-full/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ${TEMPORAL_LOCAL_CERT_DIR}:${TEMPORAL_TLS_CERTS_DIR}
       - ./config_template.yaml:/etc/temporal/config/config_template.yaml
     environment:
-      - "SERVICES=frontend:matching:history:worker:internal-frontend"
+      - "TEMPORAL_SERVICES=frontend:matching:history:worker:internal-frontend"
       - "CASSANDRA_SEEDS=cassandra"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
       - "TEMPORAL_CLI_ADDRESS=temporal:7233" # used by tctl. Will be deprecated


### PR DESCRIPTION
## Summary

- Replace deprecated `SERVICES` env var with `TEMPORAL_SERVICES` in `compose/docker-compose-multirole.yaml` and `tls/tls-full/docker-compose.yml`
- Add CI validation to the multirole test job that checks each container is running only its expected service role and that ringpop membership is correctly wired on the internal network

## Validation added

**Service role isolation** — uses `/proc/net/tcp` inside each container to verify:
- Each service is listening on its expected gRPC port (history→7234, matching→7235, frontend→7237, frontend2→7236)
- No container is binding a port belonging to a different service role

**Ringpop membership reachability** — for history (6934) and matching (6935):
- Confirms the membership port is listening inside the container
- Confirms the port is reachable cross-container from `temporal-admin-tools` on `temporal-network`, verifying ringpop is bound to the right network interface and not just loopback