### PR TITLE
fix: increase create-namespace retry attempts and make timeout configurable

### DIFF
--- a/compose/scripts/create-namespace.sh
+++ b/compose/scripts/create-namespace.sh
@@ -3,25 +3,63 @@ set -eu
 
 NAMESPACE=${DEFAULT_NAMESPACE:-default}
 TEMPORAL_ADDRESS=${TEMPORAL_ADDRESS:-temporal:7233}
+MAX_ATTEMPTS=${TEMPORAL_HEALTH_CHECK_MAX_ATTEMPTS:-30}
+SLEEP_SECONDS=${TEMPORAL_HEALTH_CHECK_SLEEP_SECONDS:-5}
 
 echo "Waiting for Temporal server port to be available..."
-nc -z -w 10 $(echo $TEMPORAL_ADDRESS | cut -d: -f1) $(echo $TEMPORAL_ADDRESS | cut -d: -f2)
+SERVER_HOST=$(echo "$TEMPORAL_ADDRESS" | cut -d: -f1)
+SERVER_PORT=$(echo "$TEMPORAL_ADDRESS" | cut -d: -f2)
+attempt=1
+while ! nc -z -w 10 "$SERVER_HOST" "$SERVER_PORT"; do
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "Temporal server port did not become available after $MAX_ATTEMPTS attempts"
+    exit 1
+  fi
+
+  echo "Temporal server port not ready yet, waiting... (attempt $attempt/$MAX_ATTEMPTS)"
+  attempt=$((attempt + 1))
+  sleep "$SLEEP_SECONDS"
+done
 echo 'Temporal server port is available'
 
 echo 'Waiting for Temporal server to be healthy...'
-max_attempts=3
-attempt=0
+attempt=1
 
-until temporal operator cluster health --address $TEMPORAL_ADDRESS; do
-  attempt=$((attempt + 1))
-  if [ $attempt -ge $max_attempts ]; then
-    echo "Server did not become healthy after $max_attempts attempts"
+while :; do
+  if temporal operator cluster health --address "$TEMPORAL_ADDRESS"; then
+    break
+  fi
+
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "Server did not become healthy after $MAX_ATTEMPTS attempts"
     exit 1
   fi
-  echo "Server not ready yet, waiting... (attempt $attempt/$max_attempts)"
-  sleep 5
+
+  echo "Server not ready yet, waiting... (attempt $attempt/$MAX_ATTEMPTS)"
+  attempt=$((attempt + 1))
+  sleep "$SLEEP_SECONDS"
 done
 
 echo "Server is healthy, creating namespace '$NAMESPACE'..."
-temporal operator namespace describe -n $NAMESPACE --address $TEMPORAL_ADDRESS || temporal operator namespace create -n $NAMESPACE --address $TEMPORAL_ADDRESS
-echo "Namespace '$NAMESPACE' created"
+
+attempt=1
+while :; do
+  if temporal operator namespace describe -n "$NAMESPACE" --address "$TEMPORAL_ADDRESS" >/dev/null 2>&1; then
+    echo "Namespace '$NAMESPACE' already exists"
+    break
+  fi
+
+  if temporal operator namespace create -n "$NAMESPACE" --address "$TEMPORAL_ADDRESS" >/dev/null 2>&1; then
+    echo "Namespace '$NAMESPACE' created"
+    break
+  fi
+
+  if [ "$attempt" -ge "$MAX_ATTdMPTS" ]; then
+    echo "Failed to create namespace '$NAMESPACE' after $MAX_ATTEMPTS attempts"
+    exit 1
+  fi
+
+  echo "Namespace operation not ready yet, waiting... (attempt $attempt/$MAX_ATTEMPTS)"
+  attempt=$((attempt + 1))
+  sleep "$SLEEP_SECONDS"
+done


### PR DESCRIPTION
Fixes #136

## Problem

`temporal-create-namespace` was hardcoded to 3 health check attempts (~45 seconds total). On slower machines or fresh setups, the Temporal server takes longer to fully initialize its membership ring — so the script exhausts its retries and exits before the server is ready.

The existing `temporal` container healthcheck uses `nc -z localhost 7233`, which only checks TCP connectivity. The port opens before the membership ring stabilizes, so `service_healthy` fires too early and `temporal-create-namespace` starts against a server that isn't truly ready.


## Fix

- Increase default health check attempts from 3 to 30 (2.5 minutes at 5s intervals)
- Add `TEMPORAL_HEALTH_CHECK_MAX_ATTEMPTS` and `TEMPORAL_HEALTH_CHECK_SLEEP_SECONDS` env vars for overriding
- Add retry loop to the port wait step (previously a single `nc` call with no retry)
- Add retry loop to the namespace create/describe step (previously no retry)
- Fix unquoted variable references throughout