### PR TITLE
Updating TLS samples to use Elasticsearch and reference temporal cli

### DIFF
--- a/tls/tls-full/README.md
+++ b/tls/tls-full/README.md
@@ -38,7 +38,7 @@ cluster-internode    |              |                         |                 
 ./start-temporal.sh
 ```
 
-3. You can use docker to enter the cli containers and use `tctl` like this (in another terminal):
+3. You can use docker to enter the cli containers and use the `temporal` CLI like this (in another terminal):
 
 ```bash
 docker exec -it tls-full-temporal-cli-admin-1 bash
@@ -47,7 +47,7 @@ docker exec -it tls-full-temporal-cli-accounting-1 bash
 ```
 
 Environment variables are set up to provide the `development` and `accounting` containers with access to namespaces with the respective names.
-(You'll have to create them first with `tctl namespace register`.)
+(You'll have to create them first from the admin container with `temporal operator namespace create -n development` and `temporal operator namespace create -n accounting`.)
 
 4. But you might notice that all three containers actually have identical (full admin-level) permissions!
 That's because there's no ClaimMapper or Authorizer actually examining the client certs to determine permissions.

--- a/tls/tls-full/README.md
+++ b/tls/tls-full/README.md
@@ -38,7 +38,7 @@ cluster-internode    |              |                         |                 
 ./start-temporal.sh
 ```
 
-3. You can use docker to enter the cli containers and use the `temporal` CLI like this (in another terminal):
+3. You can use docker to enter the cli containers and use the Temporal CLI like this (in another terminal):
 
 ```bash
 docker exec -it tls-full-temporal-cli-admin-1 bash
@@ -47,7 +47,7 @@ docker exec -it tls-full-temporal-cli-accounting-1 bash
 ```
 
 Environment variables are set up to provide the `development` and `accounting` containers with access to namespaces with the respective names.
-(You'll have to create them first from the admin container with `temporal operator namespace create -n development` and `temporal operator namespace create -n accounting`.)
+(You'll have to create them first from the admin container with `temporal operator namespace create -n <development/accounting>`.)
 
 4. But you might notice that all three containers actually have identical (full admin-level) permissions!
 That's because there's no ClaimMapper or Authorizer actually examining the client certs to determine permissions.

--- a/tls/tls-full/docker-compose.yml
+++ b/tls/tls-full/docker-compose.yml
@@ -3,6 +3,18 @@ services:
     image: cassandra:3.11
     ports:
       - "9042:9042"
+  elasticsearch:
+    image: elasticsearch:7.17.27
+    ports:
+      - "9200:9200"
+    environment:
+      - "cluster.routing.allocation.disk.threshold_enabled=true"
+      - "cluster.routing.allocation.disk.watermark.low=512mb"
+      - "cluster.routing.allocation.disk.watermark.high=256mb"
+      - "cluster.routing.allocation.disk.watermark.flood_stage=128mb"
+      - "discovery.type=single-node"
+      - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
+      - "xpack.security.enabled=false"
   temporal:
     image: temporalio/auto-setup:${SERVER_TAG:-latest}
     ports:
@@ -12,8 +24,12 @@ services:
       - ${TEMPORAL_LOCAL_CERT_DIR}:${TEMPORAL_TLS_CERTS_DIR}
       - ./config_template.yaml:/etc/temporal/config/config_template.yaml
     environment:
-      - "TEMPORAL_SERVICES=frontend:matching:history:worker:internal-frontend"
+      - "SERVICES=frontend:matching:history:worker:internal-frontend"
+      - "BIND_ON_IP=0.0.0.0"
       - "CASSANDRA_SEEDS=cassandra"
+      - "ENABLE_ES=true"
+      - "ES_SEEDS=elasticsearch"
+      - "ES_VIS_INDEX=temporal_visibility_v1_dev"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
       - "TEMPORAL_CLI_ADDRESS=temporal:7233" # used by tctl. Will be deprecated
       - "TEMPORAL_CLI_TLS_CA=${TEMPORAL_TLS_CERTS_DIR}/cluster/ca/server-intermediate-ca.pem"
@@ -29,6 +45,7 @@ services:
       - "TEMPORAL_TLS_SERVER_NAME=internode.cluster-x.contoso.com"
     depends_on:
       - cassandra
+      - elasticsearch
   temporal-ui:
     image: temporalio/ui:${UI_TAG:-latest}
     ports:

--- a/tls/tls-simple/docker-compose.yml
+++ b/tls/tls-simple/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "9042:9042"
   elasticsearch:
-    image: elasticsearch:7.10.1
+    image: elasticsearch:7.17.27
     ports:
       - "9200:9200"
     environment:


### PR DESCRIPTION
## What was changed
Readme update, adding Elasticsearch to the docker-compose for tls-full, updating tls-simple to use elasticsearch 7.17.27

## Why?
Current tls-full sample did not run as-is. Took this opportunity to add references to Temporal CLI over tctl

## Checklist

1. How was this tested:
Ran steps from README to validate the changes were working again.
